### PR TITLE
Add PatientFrame integration and enhance MPRViewer features

### DIFF
--- a/docs/devel/mpr_viewer.md
+++ b/docs/devel/mpr_viewer.md
@@ -14,6 +14,10 @@
 
 ## MPR Viewer 設計ドキュメント
 
+関連仕様:
+
+- `Patient Orientation` 仕様: `docs/devel/patient_orientation.md`
+
 ## 概要
 
 `MprViewer` は `BaseViewer` を継承した MPR（Multi-Planar Reconstruction）専用ビューワーである。  

--- a/docs/devel/patient_orientation.md
+++ b/docs/devel/patient_orientation.md
@@ -30,6 +30,10 @@ volume の orientation を camera 側へ反映する必要がある。
 
 したがって `Patient Orientation` は MPR だけの課題ではなく、VR を含む表示系全体の基礎仕様である。
 
+加えて、現状の DICOM ローダ (`vtkDICOMImageReader`) は `Image Orientation (Patient)` を完全には反映しない。  
+そのため `vtkImageData.GetDirectionMatrix()` が単位行列のまま下流に流れているケースがあり、  
+camera 側だけで patient matrix を補正しても整合が取り切れない。本書ではローダ層も含めて再設計する。
+
 ---
 
 ## 対象範囲
@@ -78,13 +82,20 @@ viewer が従う表示ポリシーは既存の fixed plane 規約を維持する
 
 ### 3. viewer 内部の正本は patient/world 系に寄せる
 
-少なくとも以下の座標系を区別して扱う。
+少なくとも以下の座標系を区別して扱う（詳細は §座標モデル）。
 
 - voxel index space
-- patient/world space
+- source space (VTK のローカル世界座標)
+- patient space (DICOM 由来)
 - viewer display space
 
-slice 同期や crosshair、camera preset の基準は、固定 IJK ではなく patient/world 系を正本とする。
+slice 同期や crosshair、camera preset の基準は、固定 IJK ではなく patient 系を正本とする。
+
+### 4. 患者座標規約は LPS を内部正本とする
+
+DICOM 準拠で内部表現は **LPS (Left, Posterior, Superior)** を採用する。  
+RAS との相互変換は I/O 境界（読み込み・marker 表示・外部連携）でのみ行う。  
+これにより orientation marker (L/R, A/P, H/F) の符号が一意に決まる。
 
 ---
 
@@ -105,28 +116,63 @@ slice 同期や crosshair、camera preset の基準は、固定 IJK ではなく
 
 少なくとも以下を論理的に保持する。
 
-- `ijk -> patient/world`
-- `patient/world -> ijk`
+- `IJK -> PAT`
+- `PAT -> IJK`
+- `SRC -> PAT`（= `vtkImageData.GetDirectionMatrix()`）
+- `PAT -> SRC`
 
 実装形は 4x4 matrix、direction matrix、または同等の変換表現とする。
 
+### PatientFrame 値オブジェクト
+
+変換行列の所在を明確にするため、以下の値オブジェクトを単一の正本として導入する。
+
+```python
+@dataclass(frozen=True, slots=True)
+class PatientFrame:
+    ijk_to_patient: vtk.vtkMatrix4x4
+    patient_to_ijk: vtk.vtkMatrix4x4
+    src_to_patient: vtk.vtkMatrix4x4   # = vtkImageData.GetDirectionMatrix() を 4x4 化したもの
+    convention: Literal["LPS", "RAS"] = "LPS"
+```
+
+- 配置場所: `qv/core/patient_geometry.py`（新規）を推奨
+- VR / MPR / picker / crosshair / marker は **すべて** これを参照する
+- viewer ごとの独自解釈・独自行列保持は禁止する
+
+### plane normal と patient 軸の対応
+各 plane の法線は `PatientFrame` から以下の規約で導出する（LPS 基準）。
+
+| plane | 法線方向（PAT） | 視線方向（カメラ位置→注視点） | 意味 |
+| --- | --- | --- | --- |
+| Axial | +S (Superior) | -S（足側→頭側） | 頭尾方向に法線 |
+| Coronal | +P (Posterior) | +P（前方→後方） | 前後方向に法線 |
+| Sagittal | +L (Left) | +L（左→右） | 左右方向に法線 |
+### view_up の規約
+VR camera preset の も同じ `PatientFrame` から導出する。 `view_up`
+
+| preset | camera 視線方向（PAT） | view_up（PAT） |
+| --- | --- | --- |
+| front | +P | -S |
+| back | -P | -S |
+| left | -L | -S |
+| right | +L | -S |
+| top | -S | -P |
+| bottom | +S | +P |
+これらは / の生成根拠となる。 `CameraPreset.DIRECTIONS``CameraPreset.VIEWUPS`
 ### MPR の基準
-
-MPR の `WorldPosition` は、最終的には patient/world 系の基準点として扱う。
-
+MPR の は、最終的には PAT 系の基準点として扱う。 `WorldPosition`
 これにより以下を統一できる。
-
 - 他断面への slice 投影
 - crosshair 表示
 - point sync
 - 将来の oblique 拡張
 
+の型定義は MPR 専用ではなくなるため、 または
+`qv/core/patient_geometry.py` の中立モジュールへ移設する。 `WorldPosition``qv/viewers/coordinates.py`
 ### VR の基準
-
 VR では volume 自体に patient orientation を反映したうえで、camera preset を患者基準で定義する。
-
 つまり以下の意味はデータに依らず一定であるべきとする。
-
 - `front_view`
 - `back_view`
 - `left_view`
@@ -134,57 +180,46 @@ VR では volume 自体に patient orientation を反映したうえで、camera
 - `top_view`
 - `bottom_view`
 
----
+### direction matrix の責務分担
+`vtkImageData.GetDirectionMatrix()` は VTK のレンダリングパイプラインに自動適用される。
+camera 側で再度 patient matrix を掛けると二重補正となるため、以下を厳守する。
+- volume 表示への反映: VTK 内蔵処理に任せる（`SetDirectionMatrix` を正しく設定する）
+- camera preset の方向計算: `PatientFrame` から `PAT` 軸で算出し、SRC 系へ最終投影する
+- どちらが何を担うかをコード上に明示し、二重補正を生まないこと
 
 ## MPR 仕様
-
 ### plane の意味
-
-各 plane は患者基準で以下を意味する。
-
+各 plane は患者基準で以下を意味する（再掲: §plane normal と患者軸の対応）。
 - Axial: 頭尾方向に法線を持つ断面
 - Coronal: 前後方向に法線を持つ断面
 - Sagittal: 左右方向に法線を持つ断面
 
 ### plane 表示規約
-
-既存の `docs/devel/mpr_viewer.md` の表示規約を維持する。
-
+既存の の表示規約を維持する。 `docs/devel/mpr_viewer.md`
 - Axial: 足側から頭側を見る
 - Coronal: 前方から後方を見る
 - Sagittal: 左側から右側を見る
 
 これにより、患者の左右・前後・上下の見え方は plane ごとに安定する。
-
 ### slice index
-
-slice index は viewer の都合で持つ離散値であり、正本座標ではない。  
-患者基準の位置から現在 plane の法線方向成分を求めた結果として導出されるものとする。
-
+slice index は viewer の都合で持つ離散値であり、正本座標ではない。
+PAT 位置から現在 plane の法線方向成分を求めた結果として導出されるものとする。
 つまり次を守る。
-
-- patient/world 位置から slice index を計算できる
+- PAT 位置から slice index を計算できる
 - slice index から reslice origin を再構成できる
 - 軸番号の決め打ちだけで slice 位置を決めない
 
 ### crosshair
-
-crosshair は他 viewer の現在断面位置を表示する補助情報である。  
-crosshair の基準点は patient/world 系で統一する。
-
+crosshair は他 viewer の現在断面位置を表示する補助情報である。
+crosshair の基準点は PAT 系で統一する。
+の対応も `PatientFrame` から導出可能な形へ置き換える。
+固定の plane 名→軸番号マップは最終仕様では持たない。 `CROSSHAIR_REFERENCE_PLANE`
 ### slice 操作
-
-wheel や drag による slice 移動は、画面座標ではなくその plane の法線方向移動として定義する。  
+wheel や drag による slice 移動は、画面座標ではなくその plane の法線方向移動として定義する。
 画面上の上/下、前/後のどちらを slice 増減に対応させるかは、patient orientation を canonical 表示へ写した後に決定する。
-
----
-
 ## VR 仕様
-
 ### camera preset
-
 VR の preset view は患者基準で定義する。
-
 - front: 患者前方から後方を見る
 - back: 患者後方から前方を見る
 - left: 患者左側から右側を見る
@@ -192,81 +227,96 @@ VR の preset view は患者基準で定義する。
 - top: 頭側から足側を見る
 - bottom: 足側から頭側を見る
 
+具体ベクトルは §view_up の規約 の表に従う。
 ### camera orientation
-
-camera position だけでなく、`view_up` も patient orientation を反映して決定する。  
-これにより同じ `front_view` でもデータ orientation によって上下が反転する事態を防ぐ。
-
+camera position だけでなく、 も patient orientation を反映して決定する。
+これにより同じ でもデータ orientation によって上下が反転する事態を防ぐ。 `view_up``front_view`
 ### orientation marker
-
-VR でも MPR と同様に患者基準の orientation marker を表示可能にする前提で設計する。  
+VR でも MPR と同様に患者基準の orientation marker を表示可能にする前提で設計する。
 少なくとも以下が正しく導出できる必要がある。
-
 - L / R
 - A / P
 - H / F
 
 ### MPR との整合
-
-VR は slice を持たないが、患者基準の右左前後上下は MPR と一致していなければならない。  
-MPR の plane 規約と VR の preset view 規約は同じ patient/world 基準から導出される。
-
----
-
+VR は slice を持たないが、患者基準の右左前後上下は MPR と一致していなければならない。
+MPR の plane 規約と VR の preset view 規約は同じ `PatientFrame` から導出される。
 ## 実装上の指針
-
 ### MPR
-
-- `PLANE_AXES` は canonical 表示規約を表す層として扱う
-- `PLANE_AXES_INDEX` による固定軸前提は最終仕様では置き換える
-- `world_to_slice_index()` は patient/world 基準で計算する
-- `_update_reslice()` は patient/world から reslice origin を決める
+- は canonical 表示規約を表す層として扱う `PLANE_AXES`
+- による固定軸前提は最終仕様では置き換える `PLANE_AXES_INDEX`
+- は PAT 基準で計算する `world_to_slice_index()`
+- は PAT から reslice origin を決める `_update_reslice()`
+- crosshair 系メソッド ( / / / / ) も `PatientFrame` 経由に書き換える `_slice_index_to_world``_build_crosshair_world_position``_build_crosshair_segments``_world_to_display_point``_display_to_world_point`
 
 ### VR
-
-- `VolumeViewer` の camera preset は patient matrix を反映できる形を維持する
-- volume から取得できる direction / patient matrix を camera controller に渡す
-- preset view と orientation marker は同じ patient basis を共有する
+- の patient matrix は `PatientFrame.src_to_patient` を経由して設定する `VolumeViewer`
+- `vtkImageData.SetDirectionMatrix()` を通じて VTK 内蔵経路で反映させる
+- camera preset と orientation marker は同じ `PatientFrame` を共有する
+- camera 側の追加補正と direction matrix 反映の二重適用を避ける
 
 ### 共通
-
 - 一時的な符号合わせで plane ごとに個別補正しない
 - MPR と VR で別々の患者基準を持たない
-- 変換行列の所在を明確にし、viewer ごとに独自解釈しない
-
----
+- 変換行列の所在は `PatientFrame` に集約し、viewer ごとに独自解釈しない
+- を MPR 専用モジュールから中立モジュールへ移設する `WorldPosition`
 
 ## 導入順
+順序見直し: MPR の reslice / slice index 計算は数値整合の検証が容易で、後段の crosshair / clipping との整合確認の基準にもなる。VR camera より先に MPR 側を固める。### Phase 1: ローダと PatientFrame の確立
+- DICOM 由来の orientation 情報を読み取れるローダに刷新
+    - 現状の は を取り切れない `vtkDICOMImageReader``Image Orientation (Patient)`
+    - 候補: `vtk-dicom` (`vtkDICOMReader`)、または pydicom + 自前 構築 `vtkImageData`
 
-### Phase 1: patient/world 変換の保持
+- `PatientFrame` を返すローダ API を定義
+- `vtkImageData.GetDirectionMatrix()` が DICOM の と一致すること `Image Orientation (Patient)`
+- VR と MPR の両方から `PatientFrame` を参照できる経路を用意
+- 完了条件:
+    - 既知の HFS / FFS / HFP / FFP データでローダ単体テストが通る
+    - `PatientFrame` が単位行列となるダミーデータでは現状表示と pixel 単位で一致（後方互換）
 
-- DICOM 由来の orientation 情報を読み取る
-- `ijk <-> patient/world` を保持する
-- VR と MPR の両方から参照できる形にする
-
-### Phase 2: VR camera への反映
-
-- `VolumeViewer` の patient matrix を確実に設定する
-- preset view の方向と `view_up` を患者基準で検証する
-- 必要なら orientation marker の基礎情報をここで揃える
-
-### Phase 3: MPR reslice への反映
-
-- fixed axis 前提の slice 計算を patient/world 基準へ置き換える
-- crosshair と point sync を patient/world 基準で統一する
+### Phase 2: MPR reslice への反映
+- fixed axis 前提の slice 計算を PAT 基準へ置き換える
+- / / `_slice_index_to_world()` を `PatientFrame` 経由に `_update_reslice()``world_to_slice_index()`
+- crosshair と point sync を PAT 基準で統一する
+- を patient basis から導出する形に変更 `CROSSHAIR_REFERENCE_PLANE`
 - plane 表示規約を維持したまま orientation を吸収する
 
-### Phase 4: 操作仕様の確定
+### Phase 3: VR camera への反映
+- の patient matrix を `PatientFrame.src_to_patient` から確実に設定する `VolumeViewer`
+- preset view の方向と を §view_up の規約 の表に従い実装 `view_up`
+- direction matrix の責務分担（VTK 内蔵 vs camera 補正）を明文化し、二重補正を排除
+- 必要なら orientation marker の基礎情報をここで揃える
 
-- wheel / drag / double click の意味を patient/world 基準で再定義する
+### Phase 4: 操作仕様と marker の確定
+- wheel / drag / double click の意味を PAT 基準で再定義する
 - MPR と VR の orientation marker を必要に応じて追加する
-
----
+- camera_state の azimuth/elevation のレポート単位（world / patient）を選定し統一する
+- interactor styles の slice 増減方向を patient basis に整合させる
+- 必要なら / `app.json` に表示ポリシー（marker on/off, radiological convention）を追加 `viewer.json`
 
 ## 受け入れ条件
-
+### 機能要件
 - 同一データで MPR と VR の左右前後上下の解釈が一致する
 - VR の preset view が患者基準で安定する
-- MPR の slice / crosshair / sync が patient/world 基準で整合する
+- MPR の slice / crosshair / sync が PAT 基準で整合する
 - fixed plane の表示規約を維持したまま orientation を吸収できる
 - orientation marker を導入する場合に、MPR と VR の両方で同じ基準から導出できる
+
+### テスト要件（自動化推奨）
+- HFS / FFS / HFP / FFP の 4 パターンで MPR の `L/R/A/P/H/F` が反転しない
+- 同一データで 後の VR と axial MPR の `L/R` が一致する `front_view`
+- `PatientFrame` が単位行列の場合、Phase 1 導入前の表示と pixel 単位で一致する（後方互換）
+- crosshair の交点座標が `IJK -> PAT -> IJK` のラウンドトリップで誤差 1 voxel 以内に収まる
+- direction matrix を二重適用していないこと（patient matrix 適用前後の volume bounds が PAT 系で一致）
+
+
+主な変更点まとめ:
+
+1. §背景 にローダ起因の前提崩れを明記
+2. §対象範囲 を MPR / VR / 共通基盤の 3 区分に再編し、crosshair の各メソッド名・ローダ・WorldPosition 移設まで列挙
+3. §非対象 に clipping マスク・既存 Undo/Redo state・DICOM 実装エラーを明示
+4. §基本方針 に LPS 採用を追加
+5. §座標モデル を 4 系（IJK/SRC/PAT/DSP）の表で再定義し、`PatientFrame` 値オブジェクト・plane normal 表・view_up 規約表・direction matrix 責務分担 を新設
+6. §MPR 仕様 / §VR 仕様 / §実装上の指針 を `PatientFrame` 経由前提で書き直し、対象メソッドを具体名で記載
+7. §導入順 を Phase 1: ローダ + PatientFrame → Phase 2: MPR → Phase 3: VR → Phase 4: 操作 / marker に変更し、各 Phase の完了条件を追加
+8. §受け入れ条件 に自動テスト要件 5 項目を追加

--- a/docs/devel/patient_orientation.md
+++ b/docs/devel/patient_orientation.md
@@ -1,0 +1,272 @@
+# Patient Orientation 仕様
+
+## 目的
+
+本書は、DICOM の `Patient Orientation` および関連する患者座標情報を qv 内でどのように扱うかを定義する。  
+対象は MPR に限定せず、`MprViewer` と `VolumeViewer` の両方を含む。
+
+本書の目的は以下である。
+
+- MPR と VR で座標解釈を揃える
+- fixed plane 表示と患者座標系の関係を明確にする
+- 将来の orientation marker、camera preset、crosshair、slice 操作の基準を統一する
+- 一時的な見た目調整ではなく、データ由来の orientation を正しく扱う
+
+本書は既存の以下の文書を補完する。
+
+- `docs/devel/mpr_viewer.md`
+- `docs/devel/multipanel.md`
+- `docs/devel/modify_mpr_viewer_interaction.md`
+
+---
+
+## 背景
+
+現状の `MprViewer` は固定 plane 前提で `PLANE_AXES` と `PLANE_AXES_INDEX` を用いており、  
+slice index、reslice origin、crosshair 投影の一部が軸固定の実装になっている。
+
+一方 `VolumeViewer` では slice index は持たないが、患者基準の front/back/left/right/top/bottom view を正しく扱うには、  
+volume の orientation を camera 側へ反映する必要がある。
+
+したがって `Patient Orientation` は MPR だけの課題ではなく、VR を含む表示系全体の基礎仕様である。
+
+---
+
+## 対象範囲
+
+### MPR に影響する項目
+
+- Axial / Coronal / Sagittal の plane 解釈
+- slice index と患者座標の対応
+- `vtkImageReslice` の reslice axes と origin
+- crosshair の world/patient 座標
+- viewer 上の orientation marker
+- マウスホイールや drag による slice 移動方向の意味
+
+### VR に影響する項目
+
+- front / back / left / right / top / bottom の camera preset
+- `ViewUp` を含む camera orientation
+- orientation marker
+- MPR と VR の「右/左/前/後/頭/足」の一貫性
+- 将来 3D 上に断面位置や marker を出す場合の座標整合
+
+### 本書の非対象
+
+- oblique MPR の最終仕様
+- thick slab の最終仕様
+- DICOM 以外の任意 orientation フォーマット対応
+- VR と MPR の WW/WL 連動
+- UI デザインの細部
+
+---
+
+## 基本方針
+
+### 1. 表示規約を先に固定する
+
+viewer が従う表示ポリシーは既存の fixed plane 規約を維持する。
+
+- Axial / Coronal / Sagittal の canonical な見え方は維持する
+- radiological convention を採るかどうかは plane 表示仕様側で管理する
+- `Patient Orientation` 対応によって viewer の見え方ポリシーを都度変えない
+
+### 2. データセットを表示規約へ正規化する
+
+`Patient Orientation` 対応は、データごとに表示ポリシーを変えるためではない。  
+各データセットの patient 座標系を、viewer が採用する canonical な表示規約へマッピングするために使う。
+
+### 3. viewer 内部の正本は patient/world 系に寄せる
+
+少なくとも以下の座標系を区別して扱う。
+
+- voxel index space
+- patient/world space
+- viewer display space
+
+slice 同期や crosshair、camera preset の基準は、固定 IJK ではなく patient/world 系を正本とする。
+
+---
+
+## 座標モデル
+
+### 入力として使う DICOM 情報
+
+- `Image Orientation (Patient)`
+- `Image Position (Patient)`
+- pixel spacing / slice spacing
+
+必要に応じて以下も参照対象とする。
+
+- `Patient Position`
+- 画像 series 全体から導出される slice normal
+
+### 保持すべき変換
+
+少なくとも以下を論理的に保持する。
+
+- `ijk -> patient/world`
+- `patient/world -> ijk`
+
+実装形は 4x4 matrix、direction matrix、または同等の変換表現とする。
+
+### MPR の基準
+
+MPR の `WorldPosition` は、最終的には patient/world 系の基準点として扱う。
+
+これにより以下を統一できる。
+
+- 他断面への slice 投影
+- crosshair 表示
+- point sync
+- 将来の oblique 拡張
+
+### VR の基準
+
+VR では volume 自体に patient orientation を反映したうえで、camera preset を患者基準で定義する。
+
+つまり以下の意味はデータに依らず一定であるべきとする。
+
+- `front_view`
+- `back_view`
+- `left_view`
+- `right_view`
+- `top_view`
+- `bottom_view`
+
+---
+
+## MPR 仕様
+
+### plane の意味
+
+各 plane は患者基準で以下を意味する。
+
+- Axial: 頭尾方向に法線を持つ断面
+- Coronal: 前後方向に法線を持つ断面
+- Sagittal: 左右方向に法線を持つ断面
+
+### plane 表示規約
+
+既存の `docs/devel/mpr_viewer.md` の表示規約を維持する。
+
+- Axial: 足側から頭側を見る
+- Coronal: 前方から後方を見る
+- Sagittal: 左側から右側を見る
+
+これにより、患者の左右・前後・上下の見え方は plane ごとに安定する。
+
+### slice index
+
+slice index は viewer の都合で持つ離散値であり、正本座標ではない。  
+患者基準の位置から現在 plane の法線方向成分を求めた結果として導出されるものとする。
+
+つまり次を守る。
+
+- patient/world 位置から slice index を計算できる
+- slice index から reslice origin を再構成できる
+- 軸番号の決め打ちだけで slice 位置を決めない
+
+### crosshair
+
+crosshair は他 viewer の現在断面位置を表示する補助情報である。  
+crosshair の基準点は patient/world 系で統一する。
+
+### slice 操作
+
+wheel や drag による slice 移動は、画面座標ではなくその plane の法線方向移動として定義する。  
+画面上の上/下、前/後のどちらを slice 増減に対応させるかは、patient orientation を canonical 表示へ写した後に決定する。
+
+---
+
+## VR 仕様
+
+### camera preset
+
+VR の preset view は患者基準で定義する。
+
+- front: 患者前方から後方を見る
+- back: 患者後方から前方を見る
+- left: 患者左側から右側を見る
+- right: 患者右側から左側を見る
+- top: 頭側から足側を見る
+- bottom: 足側から頭側を見る
+
+### camera orientation
+
+camera position だけでなく、`view_up` も patient orientation を反映して決定する。  
+これにより同じ `front_view` でもデータ orientation によって上下が反転する事態を防ぐ。
+
+### orientation marker
+
+VR でも MPR と同様に患者基準の orientation marker を表示可能にする前提で設計する。  
+少なくとも以下が正しく導出できる必要がある。
+
+- L / R
+- A / P
+- H / F
+
+### MPR との整合
+
+VR は slice を持たないが、患者基準の右左前後上下は MPR と一致していなければならない。  
+MPR の plane 規約と VR の preset view 規約は同じ patient/world 基準から導出される。
+
+---
+
+## 実装上の指針
+
+### MPR
+
+- `PLANE_AXES` は canonical 表示規約を表す層として扱う
+- `PLANE_AXES_INDEX` による固定軸前提は最終仕様では置き換える
+- `world_to_slice_index()` は patient/world 基準で計算する
+- `_update_reslice()` は patient/world から reslice origin を決める
+
+### VR
+
+- `VolumeViewer` の camera preset は patient matrix を反映できる形を維持する
+- volume から取得できる direction / patient matrix を camera controller に渡す
+- preset view と orientation marker は同じ patient basis を共有する
+
+### 共通
+
+- 一時的な符号合わせで plane ごとに個別補正しない
+- MPR と VR で別々の患者基準を持たない
+- 変換行列の所在を明確にし、viewer ごとに独自解釈しない
+
+---
+
+## 導入順
+
+### Phase 1: patient/world 変換の保持
+
+- DICOM 由来の orientation 情報を読み取る
+- `ijk <-> patient/world` を保持する
+- VR と MPR の両方から参照できる形にする
+
+### Phase 2: VR camera への反映
+
+- `VolumeViewer` の patient matrix を確実に設定する
+- preset view の方向と `view_up` を患者基準で検証する
+- 必要なら orientation marker の基礎情報をここで揃える
+
+### Phase 3: MPR reslice への反映
+
+- fixed axis 前提の slice 計算を patient/world 基準へ置き換える
+- crosshair と point sync を patient/world 基準で統一する
+- plane 表示規約を維持したまま orientation を吸収する
+
+### Phase 4: 操作仕様の確定
+
+- wheel / drag / double click の意味を patient/world 基準で再定義する
+- MPR と VR の orientation marker を必要に応じて追加する
+
+---
+
+## 受け入れ条件
+
+- 同一データで MPR と VR の左右前後上下の解釈が一致する
+- VR の preset view が患者基準で安定する
+- MPR の slice / crosshair / sync が patient/world 基準で整合する
+- fixed plane の表示規約を維持したまま orientation を吸収できる
+- orientation marker を導入する場合に、MPR と VR の両方で同じ基準から導出できる

--- a/qv/core/patient_geometry.py
+++ b/qv/core/patient_geometry.py
@@ -100,7 +100,7 @@ PLANE_NORMALS_PATIENT: dict[PlaneName, tuple[float, float, float]] = {
     "sagittal": (1.0, 0.0, 0.0),
 }
 
-CAMERA_ORIENTATION_PATIENT: dict[ViewName, tuple[float, float, float]] = {
+CAMERA_DIRECTIONS_PATIENT: dict[ViewName, tuple[float, float, float]] = {
     "front": (0.0, 1.0, 0.0),
     "back": (0.0, -1.0, 0.0),
     "left": (-1.0, 0.0, 0.0),

--- a/qv/core/patient_geometry.py
+++ b/qv/core/patient_geometry.py
@@ -26,7 +26,7 @@ class PatientFrame:
     patient_to_src: vtk.vtkMatrix4x4
     convention: Literal["LPS", "RAS"] = "LPS"
 
-    def patient_to_ijk(
+    def patient_point_from_continuous_ijk(
             self,
             ijk: tuple[float, float, float]
     ) -> tuple[float, float, float]:
@@ -51,7 +51,7 @@ class PatientFrame:
                 best_score = score
         return best_axis
 
-    def _source_axis_in_patient(
+    def _source_axes_in_patient(
             self,
     ) -> tuple[
         tuple[float, float, float],
@@ -208,6 +208,15 @@ def image_center_continuous_ijk(image_data: vtk.vtkImageData) -> tuple[float, fl
 
 def patient_axis_coordinate(plane: PlaneName, point: tuple[float, float, float]) -> float:
     return float(point[PLANE_TO_PATIENT_COMPONENT[plane]])
+
+
+def build_patient_point(
+        *,
+        axial: float,
+        coronal: float,
+        sagittal: float,
+) -> tuple[float, float, float]:
+    return float(sagittal), float(coronal), float(axial)
 
 
 def multiply_point(matrix: vtk.vtkMatrix4x4,

--- a/qv/core/patient_geometry.py
+++ b/qv/core/patient_geometry.py
@@ -197,7 +197,7 @@ def get_plane_reslice_axes_direction_cosines(
     )
 
 
-def iamge_center_continuous_ijk(image_data: vtk.vtkImageData) -> tuple[float, float, float]:
+def image_center_continuous_ijk(image_data: vtk.vtkImageData) -> tuple[float, float, float]:
     extent = image_data.GetExtent()
     return (
         0.5 * (float(extent[0]) + float(extent[1])),

--- a/qv/core/patient_geometry.py
+++ b/qv/core/patient_geometry.py
@@ -129,19 +129,19 @@ PLANE_DISPLAY_AXES_PATIENT: dict[
     ],
 ] = {
     "axial": (
-        (1.0, 0.0, 0.0),
-        (0.0, -1.0, 0.0),
-        (0.0, 0.0, -1.0),
+        (1.0, 0.0, 0.0),   # x_axis: screen right = patient left
+        (0.0, -1.0, 0.0),  # y_axis: screen top   = patient anterios
+        (0.0, 0.0, -1.0),  # z_axis: view normal  = toward inferior
     ),
     "coronal": (
-        (-1.0, 0.0, 0.0),
-        (0.0, 0.0, 1.0),
-        (0.0, 1.0, 0.0),
+        (1.0, 0.0, 0.0),   # x_axis: screen right = patient left
+        (0.0, 0.0, 1.0),   # y_axis: screen top   = patient superior
+        (0.0, 1.0, 0.0),   # z_axis: view normal  = toward superior
     ),
     "sagittal": (
-        (0.0, 1.0, 0.0),
-        (0.0, 0.0, 1.0),
-        (1.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0),   # x_axis: screen right = patient superior
+        (0.0, 0.0, 1.0),   # y_axis: screen top   = patient superior
+        (1.0, 0.0, 0.0),   # z_axis: view normal  = toward left
     ),
 }
 

--- a/qv/core/patient_geometry.py
+++ b/qv/core/patient_geometry.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import vtk
+
+PlaneName = Literal["axial", "coronal", "sagittal"]
+ViewName = Literal["front", "back", "left", "right", "top", "bottom"]
+
+
+@dataclass(frozen=True, slots=True)
+class WorldPosition:
+    """Patient/world-space point shared by MPR and VR."""
+    x: float
+    y: float
+    z: float
+
+
+@dataclass(frozen=True, slots=True)
+class PatientFrame:
+    """Canonical transforms derived from vtkImageData metadata."""
+    ijk_to_patient: vtk.vtkMatrix4x4
+    patient_to_ijk: vtk.vtkMatrix4x4
+    src_to_patient: vtk.vtkMatrix4x4
+    patient_to_src: vtk.vtkMatrix4x4
+    convention: Literal["LPS", "RAS"] = "LPS"
+
+    def patient_to_ijk(
+            self,
+            ijk: tuple[float, float, float]
+    ) -> tuple[float, float, float]:
+        return multiply_point(self.ijk_to_patient, ijk)
+
+    def continuous_ijk_from_patient_point(
+            self,
+            point: tuple[float, float, float]
+    ) -> tuple[float, float, float]:
+        return multiply_point(self.patient_to_ijk, point)
+
+    def source_axis_for_plane(self, plane: PlaneName) -> int:
+        normal = PLANE_NORMALS_PATIENT[plane]
+        source_axes = self._source_axes_in_patient()
+
+        best_axis = 0
+        best_score = -1.0
+        for axis, source_axis in enumerate(source_axes):
+            score = abs(dot_product(normal, source_axis))
+            if score > best_score:
+                best_axis = axis
+                best_score = score
+        return best_axis
+
+    def _source_axis_in_patient(
+            self,
+    ) -> tuple[
+        tuple[float, float, float],
+        tuple[float, float, float],
+        tuple[float, float, float],
+    ]:
+        axes: list[tuple[float, float, float]] = []
+        for column in range(3):
+            vector = (
+                self.ijk_to_patient.GetElement(0, column),
+                self.ijk_to_patient.GetElement(1, column),
+                self.ijk_to_patient.GetElement(2, column),
+            )
+            axes.append(normalize_vector(vector))
+        return axes[0], axes[1], axes[2]
+
+
+PLANE_DISPLAY_AXES_PATIENT: dict[
+    PlaneName,
+    tuple[
+        tuple[float, float, float],
+        tuple[float, float, float],
+        tuple[float, float, float],
+    ],
+] = {
+    "axial": (
+        (1.0, 0.0, 0.0),
+        (0.0, -1.0, 0.0),
+        (0.0, 0.0, -1.0),
+    ),
+    "coronal": (
+        (-1.0, 0.0, 0.0),
+        (0.0, 0.0, 1.0),
+        (0.0, 1.0, 0.0),
+    ),
+    "sagittal": (
+        (0.0, 1.0, 0.0),
+        (0.0, 0.0, 1.0),
+        (1.0, 0.0, 0.0),
+    ),
+}
+
+PLANE_NORMALS_PATIENT: dict[PlaneName, tuple[float, float, float]] = {
+    "axial": (0.0, 0.0, 1.0),
+    "coronal": (0.0, 1.0, 0.0),
+    "sagittal": (1.0, 0.0, 0.0),
+}
+
+CAMERA_ORIENTATION_PATIENT: dict[ViewName, tuple[float, float, float]] = {
+    "front": (0.0, 1.0, 0.0),
+    "back": (0.0, -1.0, 0.0),
+    "left": (-1.0, 0.0, 0.0),
+    "right": (1.0, 0.0, 0.0),
+    "top": (0.0, 0.0, -1.0),
+    "bottom": (0.0, 0.0, 1.0),
+}
+
+CAMERA_VIEWUPS_PATIENT: dict[ViewName, tuple[float, float, float]] = {
+    "front": (0.0, 0.0, -1.0),
+    "back": (0.0, 0.0, -1.0),
+    "left": (0.0, 0.0, -1.0),
+    "right": (0.0, 0.0, -1.0),
+    "top": (0.0, -1.0, 0.0),
+    "bottom": (0.0, 1.0, 0.0),
+}
+
+CAMERA_ANGLES: dict[ViewName, tuple[float, float]] = {
+    "front": (0.0, 0.0),
+    "back": (180.0, 0.0),
+    "left": (90.0, 0.0),
+    "right": (270.0, 0.0),
+    "top": (0.0, 90.0),
+    "bottom": (0.0, 270.0),
+}
+
+PLANE_TO_PATIENT_COMPONENT: dict[PlaneName, int] = {
+    "sagittal": 0,
+    "coronal": 1,
+    "axial": 2,
+}
+
+
+def build_patient_frame(image_data: vtk.vtkImageData) -> PatientFrame:
+    spacing = image_data.GetSpacing()
+    origin = image_data.GetOrigin()
+    direction3 = get_direction_matrix(image_data)
+
+    src_to_patient = vtk.vtkMatrix4x4()
+    src_to_patient.Identity()
+
+    ijk_to_patient = vtk.vtkMatrix4x4()
+    ijk_to_patient.Identity()
+
+    for row in range(3):
+        for col in range(3):
+            direction_value = direction3.GetElement(row, col)
+            src_to_patient.SetElement(row, col, direction_value)
+            ijk_to_patient.SetElement(row, col, direction_value * float(spacing[row]))
+        ijk_to_patient.SetElement(row, 3, float(origin[row]))
+
+    patient_to_ijk = vtk.vtkMatrix4x4()
+    vtk.vtkMatrix4x4.Invert(ijk_to_patient, patient_to_ijk)
+
+    patient_to_src = vtk.vtkMatrix4x4()
+    vtk.vtkMatrix4x4.Invert(src_to_patient, patient_to_src)
+
+    return PatientFrame(
+        ijk_to_patient=ijk_to_patient,
+        patient_to_ijk=patient_to_ijk,
+        src_to_patient=src_to_patient,
+        patient_to_src=patient_to_src,
+    )
+
+
+def get_direction_matrix(image_data: vtk.vtkImageData) -> vtk.vtkMatrix3x3:
+    matrix = image_data.GetDirectionMatrix() if hasattr(image_data, "GetDirectionMatrix") else None
+    if matrix is not None:
+        return matrix
+
+    identity = vtk.vtkMatrix3x3()
+    identity.Identity()
+    return identity
+
+
+def get_plane_axes(
+        plane: PlaneName,
+) -> tuple[
+    tuple[float, float, float],
+    tuple[float, float, float],
+    tuple[float, float, float],
+]:
+    return PLANE_DISPLAY_AXES_PATIENT[plane]
+
+
+def get_plane_reslice_axes_direction_cosines(
+        plane: PlaneName,
+) -> tuple[float, float, float, float, float, float, float, float, float]:
+    x_axis, y_axis, z_axis, = PLANE_DISPLAY_AXES_PATIENT[plane]
+    return (
+        x_axis[0], x_axis[1], x_axis[2],
+        y_axis[0], y_axis[1], y_axis[2],
+        z_axis[0], z_axis[1], z_axis[2],
+    )
+
+
+def iamge_center_continuous_ijk(image_data: vtk.vtkImageData) -> tuple[float, float, float]:
+    extent = image_data.GetExtent()
+    return (
+        0.5 * (float(extent[0]) + float(extent[1])),
+        0.5 * (float(extent[2]) + float(extent[3])),
+        0.5 * (float(extent[4]) + float(extent[5])),
+    )
+
+
+def patient_axis_coordinate(plane: PlaneName, point: tuple[float, float, float]) -> float:
+    return float(point[PLANE_TO_PATIENT_COMPONENT[plane]])
+
+
+def multiply_point(matrix: vtk.vtkMatrix4x4,
+                   point: tuple[float, float, float]) -> tuple[float, float, float]:
+    vec = (float(point[0]), float(point[1]), float(point[2]), 1.0)
+    result = []
+
+    for row in range(4):
+        result.append(sum(matrix.GetElement(row, col) * vec[col] for col in range(4)))
+
+    w = result[3] if abs(result[3]) > 1e-9 else 1.0
+    return result[0] / w, result[1] / w, result[2] / w
+
+
+def normalize_vector(vector: tuple[float, float, float]) -> tuple[float, float, float]:
+    norm = (vector[0] ** 2 + vector[1] ** 2 + vector[2] ** 2) ** 0.5
+    if norm < 1e-9:
+        raise ValueError("Cannot normalize zero-length vector.")
+    return vector[0] / norm, vector[1] / norm, vector[2] / norm
+
+
+def dot_product(vector1: tuple[float, float, float], vector2: tuple[float, float, float]) -> float:
+    return (vector1[0] * vector2[0]
+            + vector1[1] * vector2[1]
+            + vector1[2] * vector2[2]
+            )

--- a/qv/core/patient_geometry.py
+++ b/qv/core/patient_geometry.py
@@ -5,8 +5,59 @@ from typing import Literal
 
 import vtk
 
+
 PlaneName = Literal["axial", "coronal", "sagittal"]
 ViewName = Literal["front", "back", "left", "right", "top", "bottom"]
+
+PATIENT_AXIS_LABELS: dict[int, tuple[str, str]] = {
+    0: ("R", "L"),  # -X, +X
+    1: ("A", "P"),  # -Y, +Y
+    2: ("S", "I"),  # -Z, +Z
+}
+
+
+def dominant_orientation_label(vector: tuple[float, float, float]) -> str:
+    """
+    Return the anatomical label of the dominant patient-space axis.
+
+    Internal Patient convention in LPS:
+    +X = L, +Y = P, +Z = A
+    """
+    axis = max(range(3), key=lambda index: abs(vector[index]))
+    negative_label, positive_label = PATIENT_AXIS_LABELS[axis]
+    return positive_label if vector[axis] > 0.0 else negative_label
+
+
+def opposite_orientation_label(label: str) -> str:
+    return {
+        "L": "R",
+        "R": "L",
+        "A": "P",
+        "P": "A",
+        "S": "I",
+        "I": "S",
+    }[label]
+
+
+def orientation_labels_from_display_axes(
+        x_axis: tuple[float, float, float],
+        y_axis: tuple[float, float, float],
+) -> dict[str, str]:
+    """
+    Map displayed slice axes to edge labels.
+
+    x_axis: screen +X direction = viewer right
+    y_axis: screen +Y direction = viewer top
+    """
+    right = dominant_orientation_label(x_axis)
+    top = dominant_orientation_label(y_axis)
+
+    return {
+        "left": opposite_orientation_label(right),
+        "right": right,
+        "top": opposite_orientation_label(top),
+        "bottom": top,
+    }
 
 
 @dataclass(frozen=True, slots=True)
@@ -149,7 +200,7 @@ def build_patient_frame(image_data: vtk.vtkImageData) -> PatientFrame:
         for col in range(3):
             direction_value = direction3.GetElement(row, col)
             src_to_patient.SetElement(row, col, direction_value)
-            ijk_to_patient.SetElement(row, col, direction_value * float(spacing[row]))
+            ijk_to_patient.SetElement(row, col, direction_value * float(spacing[col]))
         ijk_to_patient.SetElement(row, 3, float(origin[row]))
 
     patient_to_ijk = vtk.vtkMatrix4x4()

--- a/qv/ui/widgets/multi_viewer_panel.py
+++ b/qv/ui/widgets/multi_viewer_panel.py
@@ -6,6 +6,8 @@ import vtk
 from PySide6 import QtCore, QtWidgets
 
 from qv.app.app_settings_manager import AppSettingsManager
+from qv.core.patient_geometry import PatientFrame
+
 from qv.utils.log_util import logger
 from  qv.viewers.controllers.mpr_sync_controller import MprSyncController
 from qv.viewers.mpr_viewer import MprPlane, MprViewer
@@ -44,6 +46,7 @@ class MultiViewerPanel(QtWidgets.QWidget):
         self._viewers: dict[str, QtWidgets.QWidget] = {}
         self.mpr_viewers: dict[MprPlane, MprViewer] = {}
         self._mpr_sync_controller = MprSyncController()
+        self._shared_patient_frame: PatientFrame | None = None
 
         self._build_shell()
         self._create_viewers()
@@ -127,7 +130,11 @@ class MultiViewerPanel(QtWidgets.QWidget):
         self._redistribute_image_data()
         self._initialize_splitter_sizes()
 
-    def set_image_data(self, image_data: vtk.vtkImageData | None) -> None:
+    def set_image_data(
+            self,
+            image_data: vtk.vtkImageData | None,
+            patient_frame: PatientFrame | None
+    ) -> None:
         """
         Store the shared image and distribute it to the active MPR viewers.
 
@@ -135,6 +142,7 @@ class MultiViewerPanel(QtWidgets.QWidget):
         to VolumeVieewer internals.
         """
         self._shared_image = image_data
+        self._shared_patient_frame = patient_frame
         self._redistribute_image_data()
 
     def _clear_content_layout(self) -> None:
@@ -222,7 +230,7 @@ class MultiViewerPanel(QtWidgets.QWidget):
             return
 
         for viewer in self._visible_mpr_viewers():
-            viewer.set_image_data(self._shared_image)
+            viewer.set_image_data(self._shared_image, patient_frame=self._shared_patient_frame,)
 
         self._synchronize_crosshair_state()
 
@@ -282,7 +290,7 @@ class MultiViewerPanel(QtWidgets.QWidget):
             logger.debug("[MultiViewerPanel] No image data to load.")
             return
 
-        self.set_image_data(image)
+        self.set_image_data(image, patient_frame=self.volume_viewer.patient_frame)
 
     def _on_mpr_slice_changed(self, plane: MprPlane, slice_index: int) -> None:
         """

--- a/qv/utils/vtk_helpers.py
+++ b/qv/utils/vtk_helpers.py
@@ -8,6 +8,7 @@ from matplotlib import pyplot as plt
 from vtkmodules.util.numpy_support import vtk_to_numpy
 
 from qv.core import geometry_utils
+from qv.core.patient_geometry import PatientFrame, build_patient_frame
 
 
 def load_dicom_series(directory: str) -> vtk.vtkImageData:
@@ -16,6 +17,12 @@ def load_dicom_series(directory: str) -> vtk.vtkImageData:
     reader.SetDirectoryName(directory)
     reader.Update()
     return reader.GetOutput()
+
+
+def load_dicom_series_with_patient_frame(directory: str) -> tuple[vtk.vtkImageData, PatientFrame]:
+    """Load a DICOM series from a directory and return the patient frame."""
+    image = load_dicom_series(directory)
+    return image, build_patient_frame(image)
 
 
 def select_dicom_directory() -> str | None:

--- a/qv/viewers/camera/camera_controller.py
+++ b/qv/viewers/camera/camera_controller.py
@@ -7,6 +7,12 @@ import logging
 
 from qv.viewers.camera.camera_state import CameraAngle, CameraStateManager
 from qv.core import geometry_utils
+from qv.core.patient_geometry import (
+CAMERA_ANGLES,
+CAMERA_DIRECTIONS_PATIENT,
+CAMERA_VIEWUPS_PATIENT,
+PatientFrame,
+)
 
 from qv.utils import vtk_helpers
 
@@ -19,35 +25,13 @@ class CameraPreset:
     """Camera preset configuration for standard views."""
 
     # Preset directions for each view (unit sphere)
-    DIRECTIONS: dict[ViewDirection, tuple[float, float, float]] = {
-        'front': (0.0, 1.0, 0.0),
-        'back': (0.0, -1.0, 0.0),
-        'left': (1.0, 0.0, 0.0),
-        'right': (-1.0, 0.0, 0.0),
-        'top': (0.0, 0.0, -1.0),
-        'bottom': (0.0, 0.0, 1.0),
-    }
+    DIRECTIONS: CAMERA_DIRECTIONS_PATIENT
 
     # Up vectors to keep orientation
-    VIEWUPS = {
-        'front': (0.0, 0.0, -1.0),
-        'back': (0.0, 0.0, -1.0),
-        'left': (0.0, 0.0, -1.0),
-        'right': (0.0, 0.0, -1.0),
-        'top': (0.0, -1.0, 0.0),
-        'bottom': (0.0, 1.0, 0.0),
-    }
+    VIEWUPS = CAMERA_VIEWUPS_PATIENT
 
     # Azimuth and elevation angles for status display.
-    ANGLES = {
-        'front': (0.0, 0.0),
-        'back': (180, 0.0),
-        'left': (90, 0.0),
-        'right': (270, 0.0),
-        'top': (0.0, 90.0),
-        'bottom': (0.0, 270.0),
-    }
-
+    ANGLES = CAMERA_ANGLES
 
 
 class CameraController:
@@ -57,7 +41,7 @@ class CameraController:
         self.camera = camera
         self.renderer = renderer
         self.state = CameraStateManager()
-        self._patient_matrix: vtk.vtkMatrix4x4 | None = None
+        self._patient_frame: PatientFrame | None = None
 
     @property
     def azimuth(self) -> float:
@@ -73,26 +57,9 @@ class CameraController:
         """Add a callback for camera angle changes."""
         self.state.add_angle_changed_callback(callback)
 
-    def set_patient_matrix(self, matrix: vtk.vtkMatrix4x4) -> None:
-        """Set the patient matrix for the camera."""
-        self._patient_matrix = matrix
-
-    def extract_patient_matrix_from_volume(self, volume: vtk.vtkVolume) -> None:
-        """Extract the patient matrix from the volume."""
-        if volume is None:
-            self._patient_matrix = None
-            return
-
-        mapper = volume.GetMapper()
-        if mapper is None:
-            self._patient_matrix = None
-            return
-
-        image = mapper.GetInput()
-        if hasattr(image, "GetDirectionMatrix"):
-            self._patient_matrix = image.GetDirectionMatrix()
-        else:
-            self._patient_matrix = None
+    def set_patient_frame(self, frame: PatientFrame | None) -> None:
+        """Set the shared patient frame used by the loaded volume."""
+        self._patient_frame = frame
 
     def rotate(self, delta_azimuth: float, delta_elevation: float):
         """
@@ -236,10 +203,6 @@ class CameraController:
         direction = CameraPreset.DIRECTIONS[view]
         view_up = CameraPreset.VIEWUPS[view]
         target_angles = CameraPreset.ANGLES[view]
-
-        if self._patient_matrix:
-            direction = geometry_utils.transform_vector(direction, self._patient_matrix)
-            view_up = geometry_utils.transform_vector(view_up, self._patient_matrix)
 
         new_position = tuple(
             focal_point[i] + direction[i] * distance for i in range(3)

--- a/qv/viewers/camera/camera_controller.py
+++ b/qv/viewers/camera/camera_controller.py
@@ -25,7 +25,7 @@ class CameraPreset:
     """Camera preset configuration for standard views."""
 
     # Preset directions for each view (unit sphere)
-    DIRECTIONS: CAMERA_DIRECTIONS_PATIENT
+    DIRECTIONS = CAMERA_DIRECTIONS_PATIENT
 
     # Up vectors to keep orientation
     VIEWUPS = CAMERA_VIEWUPS_PATIENT

--- a/qv/viewers/mpr_viewer.py
+++ b/qv/viewers/mpr_viewer.py
@@ -51,27 +51,6 @@ class MprPlane(enum.Enum):
     SAGITTAL = "sagittal"
 
 
-# Direction cosines for vtkImageReslice.SetResliceAxesDirectionCosines(...)
-# (x_axis, y_axis, z_axis) as 3x3 row-major values.
-PLANE_AXES: dict[MprPlane, tuple[float, float, float, float, float, float, float, float, float]] = {
-    MprPlane.AXIAL: (
-        1.0, 0.0, 0.0,
-        0.0, -1.0, 0.0,
-        0.0, 0.0, -1.0,
-    ),
-    MprPlane.CORONAL: (
-        -1.0, 0.0, 0.0,
-        0.0, 0.0, 1.0,
-        0.0, 1.0, 0.0,
-    ),
-    MprPlane.SAGITTAL: (
-        0.0, 1.0, 0.0,
-        0.0, 0.0, 1.0,
-        1.0, 0.0, 0.0,
-    ),
-}
-
-
 PLANE_AXES_INDEX: dict[MprPlane, int] = {
     MprPlane.AXIAL: 2,
     MprPlane.CORONAL: 1,

--- a/qv/viewers/mpr_viewer.py
+++ b/qv/viewers/mpr_viewer.py
@@ -17,6 +17,7 @@ build_patient_point,
 get_plane_axes,
 get_plane_reslice_axes_direction_cosines,
 image_center_continuous_ijk,
+orientation_labels_from_display_axes,
 patient_axis_coordinate,
 )
 from qv.viewers.base_viewer import BaseViewer
@@ -117,14 +118,14 @@ class MprViewer(BaseViewer):
         self._slice_min: int = 0
         self._slice_max: int = 0
 
-        self._patient_frame: PatientFrame | None = None
-
         self._reslice: vtk.vtkImageReslice | None = None
         self._wl_map: vtk.vtkImageMapToWindowLevelColors | None = None
         self._image_actor: vtk.vtkImageActor | None = None
         self._interactor_style: vtk.vtkInteractorStyleImage | None = None
 
+        self._patient_frame: PatientFrame | None = None
         self._plane_overlay_actor: vtk.vtkTextActor | None = None
+        self._orientation_marker_actor:  dict[str, vtk.vtkTextActor] = {}
         self._crosshair_line_source: dict[str, vtk.vtkLineSource] = {}
         self._crosshair_actor: dict[str, vtk.vtkActor] = {}
         self._crosshair_slice_refs: dict[MprPlane, int | None] = {
@@ -140,6 +141,7 @@ class MprViewer(BaseViewer):
         self.vtk_widget.installEventFilter(self)
 
         self._init_plane_overlay()
+        self._init_orientation_marker_overlay()
         self._init_crosshair_overlay()
         self._setup_pipeline()
         self._sync_plane_overlay_text()
@@ -393,6 +395,59 @@ class MprViewer(BaseViewer):
         self.overlay_renderer.AddActor(actor)
         self._plane_overlay_actor = actor
 
+    def _init_orientation_marker_overlay(self) -> None:
+        specs: dict[str, tuple[float, float, str]] = {
+            "left": (0.02, 0.50, "left"),
+            "right": (0.98, 0.50, "right"),
+            "top": (0.50, 0.98, "center"),
+            "bottom": (0.50, 0.02, "center"),
+        }
+
+        for name, (x, y, horizontal) in specs.items():
+            actor = vtk.vtkTextActor()
+            actor.SetInput("")
+
+            text_prop = actor.GetTextProperty()
+            text_prop.SetFontFamilyToCourier()
+            text_prop.SetFontSize(14)
+            text_prop.SetColor(0.95, 0.95, 0.30)
+            text_prop.SetBold(True)
+            text_prop.SetItalic(False)
+            text_prop.SetShadow(True)
+
+            if horizontal == "left":
+                text_prop.SetJustificationToLeft()
+            elif horizontal == "right":
+                text_prop.SetJustificationToRight()
+            else:
+                text_prop.SetJustificationToCentered()
+
+            text_prop.SetVerticalJustificationToCentered()
+
+            actor.GetPositionCoordinate().SetCoordinateSystemToNormalizedViewport()
+            actor.SetPosition(x, y)
+            actor.VisibilityOff()
+
+            self.overlay_renderer.AddActor(actor)
+            self._orientation_marker_actor[name] = actor
+
+    def _set_orientation_marker_visibility(self, visible: bool) -> None:
+        for actor in self._orientation_marker_actor.values():
+            actor.SetVisibility(1 if visible else 0)
+
+    def _sync_orientation_marker_overlay(self) -> None:
+        axes_components = self._get_current_reslice_axes_components()
+        if axes_components is None:
+            self._set_orientation_marker_visibility(False)
+            return
+
+        x_axis, y_axis, _, _ = axes_components
+        labels = orientation_labels_from_display_axes(x_axis, y_axis)
+
+        for name, actor in self._orientation_marker_actor.items():
+            actor.SetInput(labels[name])
+            actor.SetVisibility(1)
+
     def _init_crosshair_overlay(self) -> None:
         """
         Create world-space crosshair actors.
@@ -610,6 +665,7 @@ class MprViewer(BaseViewer):
         )
         self._reslice.Modified()
         self._reslice.Update()
+        self._sync_orientation_marker_overlay()
 
         # Display Extent をリセットして全体を表示させる
         if self._image_actor is not None:

--- a/qv/viewers/mpr_viewer.py
+++ b/qv/viewers/mpr_viewer.py
@@ -9,19 +9,21 @@ from PySide6 import QtCore
 from PySide6.QtCore import QEvent
 
 from qv.core.window_settings import WindowSettings
+from qv.core.patient_geometry import (
+PatientFrame,
+WorldPosition,
+build_patient_frame,
+build_patient_point,
+get_plane_axes,
+get_plane_reslice_axes_direction_cosines,
+image_center_continuous_ijk,
+patient_axis_coordinate,
+)
 from qv.viewers.base_viewer import BaseViewer
 from qv.viewers.coordinates import QtDisplayPoint, VtkDisplayPoint, qt_to_vtk_display
 from qv.viewers.interactor_styles.mpr_interactor_style import MprInteractorStyle
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True, slots=True)
-class WorldPosition:
-    """An anatomical point in source-world coordinates."""
-    x: float
-    y: float
-    z: float
 
 
 @dataclass(frozen=True, slots=True)
@@ -115,6 +117,8 @@ class MprViewer(BaseViewer):
         self._slice_min: int = 0
         self._slice_max: int = 0
 
+        self._patient_frame: PatientFrame | None = None
+
         self._reslice: vtk.vtkImageReslice | None = None
         self._wl_map: vtk.vtkImageMapToWindowLevelColors | None = None
         self._image_actor: vtk.vtkImageActor | None = None
@@ -159,6 +163,11 @@ class MprViewer(BaseViewer):
     def image_data(self) -> vtk.vtkImageData | None:
         """Expose loaded image  data for interactor-style checks."""
         return self._image_data
+
+    @property
+    def patient_frame(self) -> PatientFrame | None:
+        """Return the patient frame for the current plane."""
+        return self._patient_frame
 
     def eventFilter(self, obj, event):
         """
@@ -299,24 +308,20 @@ class MprViewer(BaseViewer):
         if self._image_data is None:
             raise RuntimeError("Image data not loaded.")
 
-        origin = self._image_data.GetOrigin()
-        spacing = self._image_data.GetSpacing()
-        axis = PLANE_AXES_INDEX[self._plane]
-
-        axis_spacing = float(spacing[axis])
-        if abs(axis_spacing) < 1e-9:
-            raise RuntimeError(f"Invalid spacing for plane {self._plane.value}: {axis_spacing}.")
-
-        world_values = (
-            world_position.x,
-            world_position.y,
-            world_position.z,
+        continuous_ijk = self._patient_frame.continuous_ijk_from_patient_point(
+            (world_position.x, world_position.y, world_position.z),
         )
-        return int(round((world_values[axis] - origin[axis]) / axis_spacing))
+        axis = self._get_plane_source_axis()
+        return int(round(continuous_ijk[axis]))
 
     def _get_current_reslice_axes_components(
             self,
-    ) -> tuple[tuple[float, float, float], tuple[float, float, float], tuple[float, float, float], tuple[float, float, float]] | None:
+    ) -> tuple[
+        tuple[float, float, float],
+        tuple[float, float, float],
+        tuple[float, float, float],
+        tuple[float, float, float]
+    ] | None:
         """
         Return the active reslice basis vectors and origin.
 
@@ -326,10 +331,7 @@ class MprViewer(BaseViewer):
         if self._reslice is None or self._image_data is None:
             return None
 
-        axes = PLANE_AXES[self._plane]
-        x_axis = (axes[0], axes[1], axes[2])
-        y_axis = (axes[3], axes[4], axes[5])
-        z_axis = (axes[6], axes[7], axes[8])
+        x_axis, y_axis, z_axis = get_plane_axes(self._plane.value)
 
         origin = self._reslice.GetResliceAxesOrigin()
         if origin is None:
@@ -520,7 +522,11 @@ class MprViewer(BaseViewer):
 
         super().set_window_settings(clamped, emit_signal=emit_signal, render=render)
 
-    def set_image_data(self, image_data: vtk.vtkImageData) -> None:
+    def set_image_data(
+            self,
+            image_data: vtk.vtkImageData,
+            patient_frame: PatientFrame | None = None
+    ) -> None:
         """
         Set the shared vtkImageData and initialize this viewer's own slice state.
 
@@ -531,6 +537,7 @@ class MprViewer(BaseViewer):
             return
 
         self._image_data = image_data
+        self._patient_frame = patient_frame or build_patient_frame(image_data)
         self._reslice.SetInputData(image_data)
         logger.info("MPR image data loaded for %s", self._plane.value)
 
@@ -557,10 +564,7 @@ class MprViewer(BaseViewer):
             self._slice_max = 0
             return
 
-        extent = self._image_data.GetExtent()
-        axis = PLANE_AXES_INDEX[self._plane]
-        self._slice_min = int(extent[2 * axis])
-        self._slice_max = int(extent[2 * axis + 1])
+        self._slice_min, self._slice_max = self._get_plane_index_range(self._plane)
 
     def set_plane(self, plane: MprPlane) -> None:
         """
@@ -594,21 +598,11 @@ class MprViewer(BaseViewer):
         if self._reslice is None or self._image_data is None:
             return
 
-        self._reslice.SetResliceAxesDirectionCosines(*PLANE_AXES[self._plane])
+        self._reslice.SetResliceAxesDirectionCosines(
+            *get_plane_reslice_axes_direction_cosines(self._plane.value)
+        )
 
-        extent = self._image_data.GetExtent()
-        spacing = self._image_data.GetSpacing()
-        origin = self._image_data.GetOrigin()
-
-        cx = origin[0] + (extent[0] + extent[1]) / 2.0 * spacing[0]
-        cy = origin[1] + (extent[2] + extent[3]) / 2.0 * spacing[1]
-        cz = origin[2] + (extent[4] + extent[5]) / 2.0 * spacing[2]
-
-        world_origin = [cx, cy, cz]
-
-        axis = PLANE_AXES_INDEX[self._plane]
-        world_origin[axis] = origin[axis] + self._slice_index * spacing[axis]
-
+        world_origin = self._slice_origin_for_plane(self._plane, self._slice_index)
         self._reslice.SetResliceAxesOrigin(
             world_origin[0],
             world_origin[1],
@@ -801,18 +795,8 @@ class MprViewer(BaseViewer):
 
     def _slice_index_to_world(self, plane: MprPlane, slice_index: int) -> float:
         """Convert a slice index on the given plane to world corrdinate."""
-        if self._image_data is None:
-            raise RuntimeError("Image data not loaded.")
-
-        extent = self._image_data.GetExtent()
-        spacing = self._image_data.GetSpacing()
-        origin = self._image_data.GetOrigin()
-
-        axis = PLANE_AXES_INDEX[plane]
-        min_index = int(extent[2 * axis])
-        max_index = int(extent[2 * axis + 1])
-        clamped = max(min_index, min(int(slice_index), max_index))
-        return origin[axis] + clamped * spacing[axis]
+        point = self._slice_origin_for_plane(plane, slice_index)
+        return patient_axis_coordinate(plane.value, point)
 
     def _build_crosshair_world_position(self) -> tuple[float, float, float] | None:
         """
@@ -821,33 +805,22 @@ class MprViewer(BaseViewer):
         World space is the canonical source of truth. Each viewer then converts
         that point into its own displayed slice space.
         """
-        vertical_plane, horizontal_plane = CROSSHAIR_REFERENCE_PLANE[self._plane]
-        vertical_index = self._crosshair_slice_refs[vertical_plane]
-        horizontal_index = self._crosshair_slice_refs[horizontal_plane]
+        plane_indices: dict[MprPlane, int | None] = {
+            MprPlane.AXIAL: self._slice_index if self._plane == MprPlane.AXIAL else self._crosshair_slice_refs[MprPlane.AXIAL],
+            MprPlane.CORONAL: self._slice_index if self._plane == MprPlane.CORONAL else self._crosshair_slice_refs[MprPlane.CORONAL],
+            MprPlane.SAGITTAL: self._slice_index if self._plane == MprPlane.SAGITTAL else self._crosshair_slice_refs[MprPlane.SAGITTAL],
+        }
 
-        if vertical_index is None or horizontal_index is None:
+        if any(value is None for value in plane_indices.values()):
             logger.debug("[MprViewer:%s] Index is None, skipping crosshair rendering.",
                          self._plane.value)
             return None
 
-        if self._plane == MprPlane.AXIAL:
-            return (
-                self._slice_index_to_world(MprPlane.SAGITTAL, vertical_index),  # x
-                self._slice_index_to_world(MprPlane.CORONAL, horizontal_index), # y
-                self._slice_index_to_world(MprPlane.AXIAL, self._slice_index),  # z
-            )
-        elif self._plane == MprPlane.CORONAL:
-            return (
-                self._slice_index_to_world(MprPlane.SAGITTAL, vertical_index),
-                self._slice_index_to_world(MprPlane.CORONAL, self._slice_index),
-                self._slice_index_to_world(MprPlane.AXIAL, horizontal_index),
-            )
-        else:
-            return (
-                self._slice_index_to_world(MprPlane.SAGITTAL, self._slice_index),
-                self._slice_index_to_world(MprPlane.CORONAL, vertical_index),
-                self._slice_index_to_world(MprPlane.AXIAL, horizontal_index),
-            )
+        return build_patient_point(
+            axial=self._slice_index_to_world(MprPlane.AXIAL, plane_indices[MprPlane.AXIAL]),
+            coronal=self._slice_index_to_world(MprPlane.CORONAL, plane_indices[MprPlane.CORONAL]),
+            sagittal=self._slice_index_to_world(MprPlane.SAGITTAL, plane_indices[MprPlane.SAGITTAL]),
+        )
 
     def _build_crosshair_segments(
             self,
@@ -954,3 +927,39 @@ class MprViewer(BaseViewer):
         display_z = dx  * z_axis[0] + dy * z_axis[1] + dz * z_axis[2]
 
         return display_x, display_y, display_z
+
+    # #####################################################
+    # Patient Frame
+    # #####################################################
+    def _plane_name(self, plane: MprPlane | None) -> str:
+        """Return the plane name for the given plane."""
+        return (plane or self._plane).value
+
+    def _get_plane_source_axis(self, plane: MprPlane | None = None) -> int:
+        if self._patient_frame is None:
+            raise RuntimeError("Patient frame not initialized.")
+        return self._patient_frame.source_axis_for_plane(self._plane_name(plane))
+
+    def _get_plane_index_range(self, plane: MprPlane) -> tuple[int, int,]:
+        if self._image_data is None:
+            raise RuntimeError("Image data not loaded.")
+        axis = self._get_plane_source_axis(plane)
+        extent = self._image_data.GetExtent()
+        return int(extent[2 * axis]), int(extent[2 * axis + 1])
+
+    def _slice_origin_for_plane(
+            self,
+            plane: MprPlane,
+            slice_index: int,
+    ) -> tuple[float, float, float]:
+        if self._image_data is None or self._patient_frame is None:
+            raise RuntimeError("Image data or patient frame not loaded.")
+
+        center_ijk = list(image_center_continuous_ijk(self._image_data))
+        min_index, max_index = self._get_plane_index_range(plane)
+        axis = self._get_plane_source_axis(plane)
+        center_ijk[axis] = float(max(min_index, min(int(slice_index), max_index)))
+
+        return self._patient_frame.patient_point_from_continuous_ijk(
+            (center_ijk[0], center_ijk[1], center_ijk[2])
+        )

--- a/qv/viewers/volume_viewer.py
+++ b/qv/viewers/volume_viewer.py
@@ -17,6 +17,7 @@ import qv.utils.vtk_helpers as vtk_helpers
 from qv.app.app_settings_manager import AppSettingsManager
 from qv.core import geometry_utils
 from qv.core.window_settings import WindowSettings
+from qv.core.patient_geometry import PatientFrame
 from qv.utils.log_util import log_io, log_kpi
 from qv.operations.clipping.clipping_operation import ClippingOperation, CLIPPED_SCALAR, ClipMode
 from qv.viewers.interactor_styles.clipping_interactor_style import ClippingInteractorStyle
@@ -62,6 +63,8 @@ class VolumeViewer(BaseViewer):
         self.opacity_func: vtk.vtkPiecewiseFunction | None = None
         self.mask_image: vtk.vtkImageData | None = None
 
+        self._patient_frame: PatientFrame | None = None
+
         # Window/level attributes
         self.delta_per_pixel: float = 1.0
 
@@ -101,6 +104,10 @@ class VolumeViewer(BaseViewer):
         super().__init__(settings_manager=settings_manager, parent=parent)
         self.vtk_widget.installEventFilter(self)
         self._setup_clipping()
+
+    @property
+    def patient_frame(self) -> PatientFrame | None:
+        return self._patient_frame
 
     def setup_interactor_style(self) -> None:
         """Set up the interactor style for volume viewer."""

--- a/qv/viewers/volume_viewer.py
+++ b/qv/viewers/volume_viewer.py
@@ -386,7 +386,7 @@ class VolumeViewer(BaseViewer):
                     out.GetScalarTypeAsString(),
                 )
 
-        self.camera_controller.extract_patient_matrix_from_volume(self.volume)
+        self.camera_controller.set_patient_frame(self.volume)
         self.camera_controller.reset_to_bounds(self.volume.GetBounds(), view='front')
         self._set_camera_parallel_from_current()
 

--- a/tests/viewers/conftest.py
+++ b/tests/viewers/conftest.py
@@ -75,3 +75,27 @@ def mpr_viewer(qtbot, settings_manager, monkeypatch):
     viewer = MprViewer(settings_manager=settings_manager)
     qtbot.addWidget(viewer)
     return viewer
+
+
+@pytest.fixture
+def oriented_sample_image_data(sample_image_data):
+    image = vtk.vtkImageData()
+    image.DeepCopy(sample_image_data)
+
+    direction = vtk.vtkMatrix3x3()
+    direction.Identity()
+    direction.SetElement(0, 0, 0.0)
+    direction.SetElement(1, 0, 1.0)
+    direction.SetElement(2, 0, 0.0)
+
+    direction.SetElement(0, 1, 1.0)
+    direction.SetElement(1, 1, 0.0)
+    direction.SetElement(2, 1, 0.0)
+
+    direction.SetElement(0, 2, 1.0)
+    direction.SetElement(1, 2, 0.0)
+    direction.SetElement(2, 2, 0.0)
+
+    image.SetDirectionMatrix(direction)
+    image.Modified()
+    return image

--- a/tests/viewers/test_mpr_viewer.py
+++ b/tests/viewers/test_mpr_viewer.py
@@ -6,6 +6,7 @@ import pytest
 from PySide6 import QtWidgets
 
 from qv.core.window_settings import WindowSettings
+from qv.core.patient_geometry import PatientFrame, build_patient_frame
 from qv.viewers.coordinates import QtDisplayPoint
 from qv.viewers.mpr_viewer import MprPlane, MprViewer, SyncRequest, WorldPosition
 
@@ -343,3 +344,36 @@ def test_request_sync_at_qt_position_emits_shift_drag_sync_request(
         assert request.update_crosshair is True
         assert request.update_slices is True
         assert request.shift_pressed is True
+
+
+def test_oriented_image_remaps_axial_slice_axis_to_patient_superior(
+        mpr_viewer,
+        oriented_sample_image_data,
+):
+
+    mpr_viewer.set_image_data(oriented_sample_image_data)
+
+    assert mpr_viewer._slice_min == 0
+    assert mpr_viewer._slice_max == 4
+    assert mpr_viewer._slice_index == 2
+
+
+def test_world_to_slice_index_uses_patient_frame_for_oriented_image(
+        mpr_viewer,
+        oriented_sample_image_data,
+):
+    frame = build_patient_frame(oriented_sample_image_data)
+    patient_point = frame.patient_point_from_continuous_ijk((1.0, 3.0, 2.0))
+
+    mpr_viewer.set_image_data(
+        oriented_sample_image_data,
+        patient_frame=frame,
+    )
+
+    assert mpr_viewer.world_to_slice_index(
+        WorldPosition(
+            x=patient_point[0],
+            y=patient_point[1],
+            z=patient_point[2],
+        )
+    ) == 3


### PR DESCRIPTION
### Summary

This pull request introduces several updates and refactors, focusing on improving the handling of patient-world coordinate transformations and MPRViewer functionality:

- Added orientation marker overlay on MPRViewer.
- Integrated `PatientFrame` into `MprViewer`, `VolumeViewer`, and `MultiViewerPanel` for consistent handling of patient-world transformations.
- Replaced `_patient_matrix` with `_patient_frame` across viewers, ensuring unified logic for geometry operations.
- Added new utility functions, including `load_dicom_series_with_patient_frame`.
- Created `patient_geometry.py` to centralize patient-world coordinate utilities, including transforms, normals, and camera presets.
- Refactored methods for slice and crosshair alignment based on patient-world coordinates.
- Updated documentation to cover unified patient-world transformations and MPR/VR specifications.

### Related Changes

- Fixed redundant constants and improved code clarity in MPRViewer.
- Standardized camera preset definitions.

### Testing

- Adjusted and added tests for oriented image data and slice remapping to verify functionality.

### Documentation

- Updated developer documentation to include patient orientation specifications and related DICOM loader issues.